### PR TITLE
Remove duplicate Type in desktop launcher

### DIFF
--- a/maestral_qt/resources/maestral.desktop
+++ b/maestral_qt/resources/maestral.desktop
@@ -9,6 +9,4 @@ TryExec = maestral_qt
 Exec = maestral_qt
 Hidden = false
 Terminal = false
-Type = Application
 Categories = Network;FileTransfer;
-


### PR DESCRIPTION
Hi.
While building the snap I found this error.
The Type is declared twice (the same issue can be found in the maestral repo)