### PR TITLE
Allow choosing the Dropbox folder directly

### DIFF
--- a/maestral_qt/resources/settings_window.ui
+++ b/maestral_qt/resources/settings_window.ui
@@ -138,7 +138,7 @@
      <item row="5" column="0">
       <widget class="QLabel" name="labelDropboxPathTitle">
        <property name="text">
-        <string>Dropbox folder location:</string>
+        <string>Local Dropbox folder:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/maestral_qt/resources/setup_dialog.ui
+++ b/maestral_qt/resources/setup_dialog.ui
@@ -331,7 +331,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Maestral has been successfully linked with your Dropbox account.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Please select the location of your Dropbox folder below. Maestral will create a new folder named &quot;{0}&quot; in the selected location. In the next step, you will be asked to choose which folders to sync.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Maestral has been successfully linked with your Dropbox account.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-family:'Helvetica Neue Light'; color:#000000;&quot;&gt;Please select a local folder for your Dropbox.&lt;/span&gt; If the folder is not empty, you will be given the option to delete its contents or merge it with your Dropbox. In the next step, you will be asked to choose which folders to sync.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>

--- a/maestral_qt/utils.py
+++ b/maestral_qt/utils.py
@@ -5,7 +5,9 @@ Created on Wed Oct 31 16:23:13 2018
 
 @author: samschott
 """
+# system imports
 import sys
+import os
 import platform
 
 # external packages
@@ -40,6 +42,18 @@ thread_pool.setMaxThreadCount(10)
 # ======================================================================================
 # Helper functions
 # ======================================================================================
+
+
+def is_empty(dirname):
+    """Checks if a directory is empty."""
+
+    try:
+        with os.scandir(dirname) as sciter:
+            next(sciter)
+    except StopIteration:
+        return True
+
+    return False
 
 
 def elide_string(string, font=None, pixels=200, side="right"):


### PR DESCRIPTION
This PR modifies the selection dialogs so that the local Dropbox folder itself is chosen and not its parent directory.

See https://github.com/SamSchott/maestral/issues/347.