### PR TITLE
[main.py] Fix maestral daemon startup

### DIFF
--- a/src/maestral_qt/__main__.py
+++ b/src/maestral_qt/__main__.py
@@ -4,6 +4,7 @@
 import argparse
 
 # local imports
+from maestral.daemon import Start
 from maestral_qt.main import run
 
 
@@ -17,7 +18,7 @@ def main():
     parser.add_argument("-c", "--config-name", default="maestral")
     parsed_args = parser.parse_args()
 
-    run(parsed_args.config_name)
+    run(parsed_args.config_name, Start.Uninitialized)
 
 
 if __name__ == "__main__":

--- a/src/maestral_qt/main.py
+++ b/src/maestral_qt/main.py
@@ -607,5 +607,6 @@ def run(config_name, start_result: Start):
     app.setQuitOnLastWindowClosed(False)
 
     maestral_gui = MaestralGuiApp(config_name)
+    start_result = start_maestral_daemon_process(config_name=maestral_gui.config_name)
     maestral_gui.load_maestral(start_result)
     sys.exit(app.exec())


### PR DESCRIPTION
Closes [#1147](https://github.com/samschott/maestral/issues/1147) and [#33](https://github.com/samschott/maestral-qt/issues/33#issue-3765347249).

*   Passes an uninitialized `maestral.daemon.Start` state to `maestral_qt.main.run`.
*   Adds missing call to `maestral.daemon.start_maestral_daemon_process` in `mastral_qt.main.run`.
*   Passes along resulting `maestral.daemon.Start` value to `maestral_qt.main.MaestralGuiApp`.